### PR TITLE
Fix build on Windows - add UTF-8 encoding option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+
 repositories {
   mavenCentral()
   maven("https://jitpack.io")


### PR DESCRIPTION
Project does not compile on Windows out of the box due to wrong default encoding (cp1251).
This addition fixes it.
